### PR TITLE
Fix typo in install guide

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -1,6 +1,6 @@
 # Install
 
-The samples are test in:
+The samples where tested in:
 
 - macOS Ventura.
 - Windows 10/11.


### PR DESCRIPTION
## Summary
- update the install guide to say **"where tested"** instead of **"are tested"**