### PR TITLE
Fix #103

### DIFF
--- a/TGC.MonoGame.Samples/Samples/Physics/BEPU/PyramidOfBoxes.cs
+++ b/TGC.MonoGame.Samples/Samples/Physics/BEPU/PyramidOfBoxes.cs
@@ -13,274 +13,267 @@ using TGC.MonoGame.Samples.Physics.Bepu;
 using TGC.MonoGame.Samples.Viewer;
 using NumericVector3 = System.Numerics.Vector3;
 
-namespace TGC.MonoGame.Samples.Samples.Physics.Bepu
+namespace TGC.MonoGame.Samples.Samples.Physics.Bepu;
+
+/// <summary>
+///     Pyramid Of Boxes:
+///     Ported sample from bepu physics 2
+///     https://github.com/bepu/bepuphysics2/blob/master/Demos/Demos/PyramidDemo.cs
+///     Author: Ronán Ariel Vinitzca.
+/// </summary>
+public class PyramidOfBoxes : TGCSample
 {
+    private List<Matrix> _activeBoxesWorld;
+    private List<BodyHandle> _boxHandles;
+    private Camera _camera;
+    private bool _canShoot = true;
+    private CubePrimitive _cubePrimitive;
+    private List<Matrix> _inactiveBoxesWorld;
+    private List<float> _radii;
+    private Random _random;
+    private List<BodyHandle> _sphereHandles;
+    private SpherePrimitive _spherePrimitive;
+    private List<Matrix> _spheresWorld;
+    private SpriteFont _spriteFont;
+    
+    //Note that the buffer pool used by the simulation is not considered to be *owned* by the simulation. The simulation merely uses the pool.
+    //Disposing the simulation will not dispose or clear the buffer pool.
     /// <summary>
-    ///     Pyramid Of Boxes:
-    ///     Ported sample from bepu physics 2
-    ///     https://github.com/bepu/bepuphysics2/blob/master/Demos/Demos/PyramidDemo.cs
-    ///     Author: Ronán Ariel Vinitzca.
+    ///     Gets the buffer pool used by the demo's simulation.
     /// </summary>
-    public class PyramidOfBoxes : TGCSample
+    private BufferPool _bufferPool;
+    
+    /// <summary>
+    ///     Gets the simulation created by the demo's Initialize call.
+    /// </summary>
+    private Simulation _simulation;
+
+    /// <summary>
+    ///     Gets the thread dispatcher available for use by the simulation.
+    /// </summary>
+    private SimpleThreadDispatcher _threadDispatcher;
+    
+    public PyramidOfBoxes(TGCViewer game) : base(game)
     {
-        private List<Matrix> _activeBoxesWorld;
+        Category = TGCSampleCategory.Physics;
+        Name = "BepuPhysics - Pyramid of boxes";
+        Description = "A pyramid of boxes, because you can't have a physics engine without pyramids of boxes.";
+    }
 
-        private List<BodyHandle> _boxHandles;
+    public override void Initialize()
+    {
+        _bufferPool = new BufferPool();
+        //Generally, shoving as many threads as possible into the simulation won't produce the best results on systems with multiple logical cores per physical core.
+        //Environment.ProcessorCount reports logical core count only, so we'll use a simple heuristic here- it'll leave one or two logical cores idle.
+        //For the common Intel quad core with hyperthreading, this'll use six logical cores and leave two logical cores free to be used for other stuff.
+        //This is by no means perfect. To maximize performance, you'll need to profile your simulation and target hardware.
+        //Note that issues can be magnified on older operating systems like Windows 7 if all logical cores are given work.
 
-        private Camera _camera;
+        //Generally, the more memory bandwidth you have relative to CPU compute throughput, and the more collision detection heavy the simulation is relative to solving,
+        //the more benefit you get out of SMT/hyperthreading. 
+        //For example, if you're using the 64 core quad memory channel AMD 3990x on a scene composed of thousands of ragdolls, 
+        //there won't be enough memory bandwidth to even feed half the physical cores. Using all 128 logical cores would just add overhead.
 
-        private bool _canShoot = true;
+        //It may be worth using something like hwloc to extract extra information to reason about.
+        var targetThreadCount = Math.Max(1,
+            Environment.ProcessorCount > 4 ? Environment.ProcessorCount - 2 : Environment.ProcessorCount - 1);
+        _threadDispatcher = new SimpleThreadDispatcher(targetThreadCount);
 
-        private CubePrimitive _cubePrimitive;
+        var size = GraphicsDevice.Viewport.Bounds.Size;
+        size.X /= 2;
+        size.Y /= 2;
+        _camera = new FreeCamera(GraphicsDevice.Viewport.AspectRatio, new Vector3(0, 25, 160), size);
 
-        private List<Matrix> _inactiveBoxesWorld;
+        base.Initialize();
+    }
 
-        private List<float> _radii;
+    protected override void LoadContent()
+    {
+        _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
 
-        private Random _random;
+        _simulation = Simulation.Create(_bufferPool, new NarrowPhaseCallbacks(new SpringSettings(30, 1)),
+            new PoseIntegratorCallbacks(new NumericVector3(0, -10, 0)), new SolveDescription(8, 1));
 
-        private List<BodyHandle> _sphereHandles;
+        _sphereHandles = new List<BodyHandle>();
+        _activeBoxesWorld = new List<Matrix>();
+        _inactiveBoxesWorld = new List<Matrix>();
+        _spheresWorld = new List<Matrix>();
+        _random = new Random();
+        _boxHandles = new List<BodyHandle>(800);
+        _radii = new List<float>();
 
-        private SpriteFont _spriteFont;
-
-        private SpherePrimitive _spherePrimitive;
-
-        private List<Matrix> _spheresWorld;
-
-        public PyramidOfBoxes(TGCViewer game) : base(game)
+        var boxShape = new Box(1, 1, 1);
+        var boxInertia = boxShape.ComputeInertia(1);
+        var boxIndex = _simulation.Shapes.Add(boxShape);
+        const int pyramidCount = 40;
+        for (var pyramidIndex = 0; pyramidIndex < pyramidCount; ++pyramidIndex)
         {
-            Category = TGCSampleCategory.Physics;
-            Name = "BepuPhysics - Pyramid of boxes";
-            Description = "A pyramid of boxes, because you can't have a physics engine without pyramids of boxes.";
-        }
-
-        /// <summary>
-        ///     Gets the simulation created by the demo's Initialize call.
-        /// </summary>
-        public Simulation Simulation { get; protected set; }
-
-        //Note that the buffer pool used by the simulation is not considered to be *owned* by the simulation. The simulation merely uses the pool.
-        //Disposing the simulation will not dispose or clear the buffer pool.
-        /// <summary>
-        ///     Gets the buffer pool used by the demo's simulation.
-        /// </summary>
-        public BufferPool BufferPool { get; private set; }
-
-        /// <summary>
-        ///     Gets the thread dispatcher available for use by the simulation.
-        /// </summary>
-        public SimpleThreadDispatcher ThreadDispatcher { get; private set; }
-
-        public override void Initialize()
-        {
-            BufferPool = new BufferPool();
-            //Generally, shoving as many threads as possible into the simulation won't produce the best results on systems with multiple logical cores per physical core.
-            //Environment.ProcessorCount reports logical core count only, so we'll use a simple heuristic here- it'll leave one or two logical cores idle.
-            //For the common Intel quad core with hyperthreading, this'll use six logical cores and leave two logical cores free to be used for other stuff.
-            //This is by no means perfect. To maximize performance, you'll need to profile your simulation and target hardware.
-            //Note that issues can be magnified on older operating systems like Windows 7 if all logical cores are given work.
-
-            //Generally, the more memory bandwidth you have relative to CPU compute throughput, and the more collision detection heavy the simulation is relative to solving,
-            //the more benefit you get out of SMT/hyperthreading. 
-            //For example, if you're using the 64 core quad memory channel AMD 3990x on a scene composed of thousands of ragdolls, 
-            //there won't be enough memory bandwidth to even feed half the physical cores. Using all 128 logical cores would just add overhead.
-
-            //It may be worth using something like hwloc to extract extra information to reason about.
-            var targetThreadCount = Math.Max(1,
-                Environment.ProcessorCount > 4 ? Environment.ProcessorCount - 2 : Environment.ProcessorCount - 1);
-            ThreadDispatcher = new SimpleThreadDispatcher(targetThreadCount);
-
-            var size = GraphicsDevice.Viewport.Bounds.Size;
-            size.X /= 2;
-            size.Y /= 2;
-            _camera = new FreeCamera(GraphicsDevice.Viewport.AspectRatio, new Vector3(0, 25, 160), size);
-
-            base.Initialize();
-        }
-
-        protected override void LoadContent()
-        {
-            _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
-            
-            Simulation = Simulation.Create(BufferPool, new NarrowPhaseCallbacks(new SpringSettings(30, 1)),
-                new PoseIntegratorCallbacks(new NumericVector3(0, -10, 0)), new SolveDescription(8, 1));
-
-            _sphereHandles = new List<BodyHandle>();
-            _activeBoxesWorld = new List<Matrix>();
-            _inactiveBoxesWorld = new List<Matrix>();
-            _spheresWorld = new List<Matrix>();
-            _random = new Random();
-            _boxHandles = new List<BodyHandle>(800);
-            _radii = new List<float>();
-
-            var boxShape = new Box(1, 1, 1);
-            var boxInertia = boxShape.ComputeInertia(1);
-            var boxIndex = Simulation.Shapes.Add(boxShape);
-            const int pyramidCount = 40;
-            for (var pyramidIndex = 0; pyramidIndex < pyramidCount; ++pyramidIndex)
+            const int rowCount = 20;
+            for (var rowIndex = 0; rowIndex < rowCount; ++rowIndex)
             {
-                const int rowCount = 20;
-                for (var rowIndex = 0; rowIndex < rowCount; ++rowIndex)
+                var columnCount = rowCount - rowIndex;
+                for (var columnIndex = 0; columnIndex < columnCount; ++columnIndex)
                 {
-                    var columnCount = rowCount - rowIndex;
-                    for (var columnIndex = 0; columnIndex < columnCount; ++columnIndex)
-                    {
-                        var bh = Simulation.Bodies.Add(BodyDescription.CreateDynamic(
-                            new NumericVector3((-columnCount * 0.5f + columnIndex) * boxShape.Width,
-                                (rowIndex + 0.5f) * boxShape.Height,
-                                (pyramidIndex - pyramidCount * 0.5f) * (boxShape.Length + 4)),
-                            boxInertia,
-                            new CollidableDescription(boxIndex, 0.1f),
-                            new BodyActivityDescription(0.01f)));
-                        _boxHandles.Add(bh);
-                    }
+                    var bh = _simulation.Bodies.Add(BodyDescription.CreateDynamic(
+                        new NumericVector3((-columnCount * 0.5f + columnIndex) * boxShape.Width,
+                            (rowIndex + 0.5f) * boxShape.Height,
+                            (pyramidIndex - pyramidCount * 0.5f) * (boxShape.Length + 4)),
+                        boxInertia,
+                        new CollidableDescription(boxIndex, 0.1f),
+                        new BodyActivityDescription(0.01f)));
+                    _boxHandles.Add(bh);
                 }
             }
-
-            //Prevent the boxes from falling into the void.
-            Simulation.Statics.Add(new StaticDescription(new NumericVector3(0, -0.5f, 0),
-                Simulation.Shapes.Add(new Box(2500, 1, 2500))));
-
-            _cubePrimitive = new CubePrimitive(GraphicsDevice, 1f, Color.White);
-
-            _spherePrimitive = new SpherePrimitive(GraphicsDevice);
-
-            var count = _boxHandles.Count;
-            GraphicsDevice.DepthStencilState = DepthStencilState.Default;
-            for (var index = 0; index < count; index++)
-            {
-                var bodyHandle = _boxHandles[index];
-                var bodyReference = Simulation.Bodies.GetBodyReference(bodyHandle);
-                var position = bodyReference.Pose.Position;
-                var quaternion = bodyReference.Pose.Orientation;
-                var world =
-                    Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
-                        quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
-
-                _cubePrimitive.Draw(world, _camera.View, _camera.Projection);
-            }
-
-            base.LoadContent();
         }
 
-        public override void Update(GameTime gameTime)
+        //Prevent the boxes from falling into the void.
+        _simulation.Statics.Add(new StaticDescription(new NumericVector3(0, -0.5f, 0),
+            _simulation.Shapes.Add(new Box(2500, 1, 2500))));
+
+        _cubePrimitive = new CubePrimitive(GraphicsDevice, 1f, Color.White);
+
+        _spherePrimitive = new SpherePrimitive(GraphicsDevice);
+
+        var count = _boxHandles.Count;
+        GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+        for (var index = 0; index < count; index++)
         {
-            //const float simulationDt = 1 / 60f;
-            //Using a fixed time per update to match the demos simulation update rate.
-            //time += 1 / 60f;
-            //In the demos, we use one time step per frame. We don't bother modifying the physics time step duration for different monitors so different refresh rates
-            //change the rate of simulation. This doesn't actually change the result of the simulation, though, and the simplicity is a good fit for the demos.
-            //In the context of a 'real' application, you could instead use a time accumulator to take time steps of fixed length as needed, or
-            //fully decouple simulation and rendering rates across different threads.
-            //(In either case, you'd also want to interpolate or extrapolate simulation results during rendering for smoothness.)
-            //Note that taking steps of variable length can reduce stability. Gradual or one-off changes can work reasonably well.
-            Simulation.Timestep(1 / 60f, ThreadDispatcher);
+            var bodyHandle = _boxHandles[index];
+            var bodyReference = _simulation.Bodies.GetBodyReference(bodyHandle);
+            var position = bodyReference.Pose.Position;
+            var quaternion = bodyReference.Pose.Orientation;
+            var world =
+                Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
+                    quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
 
-            if (Game.CurrentKeyboardState.IsKeyDown(Keys.Z) && _canShoot)
-            {
-                _canShoot = false;
-                //Create the shape that we'll launch at the pyramids when the user presses a button.
-                var radius = 0.5f + 5 * (float) _random.NextDouble();
-                var bulletShape = new Sphere(radius);
-
-                //Note that the use of radius^3 for mass can produce some pretty serious mass ratios. 
-                //Observe what happens when a large ball sits on top of a few boxes with a fraction of the mass-
-                //the collision appears much squishier and less stable. For most games, if you want to maintain rigidity, you'll want to use some combination of:
-                //1) Limit the ratio of heavy object masses to light object masses when those heavy objects depend on the light objects.
-                //2) Use a shorter timestep duration and update more frequently.
-                //3) Use a greater number of solver iterations.
-                //#2 and #3 can become very expensive. In pathological cases, it can end up slower than using a quality-focused solver for the same simulation.
-                //Unfortunately, at the moment, bepuphysics v2 does not contain any alternative solvers, so if you can't afford to brute force the the problem away,
-                //the best solution is to cheat as much as possible to avoid the corner cases.
-                var velocity = _camera.FrontDirection * 30f;
-                var position = new NumericVector3(_camera.Position.X, _camera.Position.Y, _camera.Position.Z);
-                var bodyDescription = BodyDescription.CreateConvexDynamic(position,
-                    new BodyVelocity(new NumericVector3(velocity.X, velocity.Y, velocity.Z)),
-                    bulletShape.Radius * bulletShape.Radius * bulletShape.Radius, Simulation.Shapes, bulletShape);
-
-                var bodyHandle = Simulation.Bodies.Add(bodyDescription);
-
-                _radii.Add(radius);
-                _sphereHandles.Add(bodyHandle);
-            }
-
-            if (Game.CurrentKeyboardState.IsKeyUp(Keys.Z))
-            {
-                _canShoot = true;
-            }
-
-            _activeBoxesWorld.Clear();
-            _inactiveBoxesWorld.Clear();
-            var count = _boxHandles.Count;
-            for (var index = 0; index < count; index++)
-            {
-                var bodyHandle = _boxHandles[index];
-                var bodyReference = Simulation.Bodies.GetBodyReference(bodyHandle);
-                var position = bodyReference.Pose.Position;
-                var quaternion = bodyReference.Pose.Orientation;
-                var world =
-                    Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
-                        quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
-
-                if (bodyReference.Awake)
-                    _activeBoxesWorld.Add(world);
-                else
-                    _inactiveBoxesWorld.Add(world);
-            }
-
-            _spheresWorld.Clear();
-            var sphereCount = _sphereHandles.Count;
-            for (var index = 0; index < sphereCount; index++)
-            {
-                var bodyHandle = _sphereHandles[index];
-                var bodyReference = Simulation.Bodies.GetBodyReference(bodyHandle);
-                var position = bodyReference.Pose.Position;
-                var quaternion = bodyReference.Pose.Orientation;
-                var world =
-                    Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
-                        quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
-                _spheresWorld.Add(world);
-            }
-
-            _camera.Update(gameTime);
-
-            Game.Gizmos.UpdateViewProjection(_camera.View, _camera.Projection);
-
-            base.Update(gameTime);
+            _cubePrimitive.Draw(world, _camera.View, _camera.Projection);
         }
 
-        public override void Draw(GameTime gameTime)
+        base.LoadContent();
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        //const float simulationDt = 1 / 60f;
+        //Using a fixed time per update to match the demos simulation update rate.
+        //time += 1 / 60f;
+        //In the demos, we use one time step per frame. We don't bother modifying the physics time step duration for different monitors so different refresh rates
+        //change the rate of simulation. This doesn't actually change the result of the simulation, though, and the simplicity is a good fit for the demos.
+        //In the context of a 'real' application, you could instead use a time accumulator to take time steps of fixed length as needed, or
+        //fully decouple simulation and rendering rates across different threads.
+        //(In either case, you'd also want to interpolate or extrapolate simulation results during rendering for smoothness.)
+        //Note that taking steps of variable length can reduce stability. Gradual or one-off changes can work reasonably well.
+        _simulation.Timestep(1 / 60f, _threadDispatcher);
+
+        if (Game.CurrentKeyboardState.IsKeyDown(Keys.Z) && _canShoot)
         {
-            Game.Background = Color.Black;
-            
-            var count = _boxHandles.Count;
-            GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+            _canShoot = false;
+            //Create the shape that we'll launch at the pyramids when the user presses a button.
+            var radius = 0.5f + 5 * (float)_random.NextDouble();
+            var bulletShape = new Sphere(radius);
 
-            _cubePrimitive.Effect.DiffuseColor = new Vector3(1f, 0f, 0f);
-            _activeBoxesWorld.ForEach(boxWorld => _cubePrimitive.Draw(boxWorld, _camera.View, _camera.Projection));
-            _cubePrimitive.Effect.DiffuseColor = new Vector3(0.1f, 0.1f, 0.3f);
-            _inactiveBoxesWorld.ForEach(boxWorld => _cubePrimitive.Draw(boxWorld, _camera.View, _camera.Projection));
+            //Note that the use of radius^3 for mass can produce some pretty serious mass ratios. 
+            //Observe what happens when a large ball sits on top of a few boxes with a fraction of the mass-
+            //the collision appears much squishier and less stable. For most games, if you want to maintain rigidity, you'll want to use some combination of:
+            //1) Limit the ratio of heavy object masses to light object masses when those heavy objects depend on the light objects.
+            //2) Use a shorter timestep duration and update more frequently.
+            //3) Use a greater number of solver iterations.
+            //#2 and #3 can become very expensive. In pathological cases, it can end up slower than using a quality-focused solver for the same simulation.
+            //Unfortunately, at the moment, bepuphysics v2 does not contain any alternative solvers, so if you can't afford to brute force the the problem away,
+            //the best solution is to cheat as much as possible to avoid the corner cases.
+            var velocity = _camera.FrontDirection * 30f;
+            var position = new NumericVector3(_camera.Position.X, _camera.Position.Y, _camera.Position.Z);
+            var bodyDescription = BodyDescription.CreateConvexDynamic(position,
+                new BodyVelocity(new NumericVector3(velocity.X, velocity.Y, velocity.Z)),
+                bulletShape.Radius * bulletShape.Radius * bulletShape.Radius, _simulation.Shapes, bulletShape);
 
-            _spheresWorld.ForEach(sphereWorld => _spherePrimitive.Draw(sphereWorld, _camera.View, _camera.Projection));
+            var bodyHandle = _simulation.Bodies.Add(bodyDescription);
 
-            Game.SpriteBatch.Begin(SpriteSortMode.BackToFront, BlendState.Opaque, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
-            Game.SpriteBatch.DrawString(_spriteFont, "Box handled: " + count + ".", new Vector2(GraphicsDevice.Viewport.Width - 500, 0), Color.White);
-            Game.SpriteBatch.DrawString(_spriteFont, "Launch spheres with the 'Z' key.", new Vector2(GraphicsDevice.Viewport.Width - 500, 25), Color.White);
-            Game.SpriteBatch.End();
-            
-            base.Draw(gameTime);
+            _radii.Add(radius);
+            _sphereHandles.Add(bodyHandle);
         }
 
-        protected override void UnloadContent()
+        if (Game.CurrentKeyboardState.IsKeyUp(Keys.Z))
         {
-            // TODO check why Simulation.Dispose method sometimes fails
-            Simulation.Dispose();
-
-            BufferPool.Clear();
-
-            ThreadDispatcher.Dispose();
-
-            base.UnloadContent();
+            _canShoot = true;
         }
+
+        _activeBoxesWorld.Clear();
+        _inactiveBoxesWorld.Clear();
+        var count = _boxHandles.Count;
+        for (var index = 0; index < count; index++)
+        {
+            var bodyHandle = _boxHandles[index];
+            var bodyReference = _simulation.Bodies.GetBodyReference(bodyHandle);
+            var position = bodyReference.Pose.Position;
+            var quaternion = bodyReference.Pose.Orientation;
+            var world =
+                Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
+                    quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
+
+            if (bodyReference.Awake)
+            {
+                _activeBoxesWorld.Add(world);
+            }
+            else
+            {
+                _inactiveBoxesWorld.Add(world);
+            }
+        }
+
+        _spheresWorld.Clear();
+        var sphereCount = _sphereHandles.Count;
+        for (var index = 0; index < sphereCount; index++)
+        {
+            var bodyHandle = _sphereHandles[index];
+            var bodyReference = _simulation.Bodies.GetBodyReference(bodyHandle);
+            var position = bodyReference.Pose.Position;
+            var quaternion = bodyReference.Pose.Orientation;
+            var world =
+                Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
+                    quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
+            _spheresWorld.Add(world);
+        }
+
+        _camera.Update(gameTime);
+
+        Game.Gizmos.UpdateViewProjection(_camera.View, _camera.Projection);
+
+        base.Update(gameTime);
+    }
+
+    public override void Draw(GameTime gameTime)
+    {
+        Game.Background = Color.Black;
+
+        var count = _boxHandles.Count;
+        GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+
+        _cubePrimitive.Effect.DiffuseColor = new Vector3(1f, 0f, 0f);
+        _activeBoxesWorld.ForEach(boxWorld => _cubePrimitive.Draw(boxWorld, _camera.View, _camera.Projection));
+        _cubePrimitive.Effect.DiffuseColor = new Vector3(0.1f, 0.1f, 0.3f);
+        _inactiveBoxesWorld.ForEach(boxWorld => _cubePrimitive.Draw(boxWorld, _camera.View, _camera.Projection));
+
+        _spheresWorld.ForEach(sphereWorld => _spherePrimitive.Draw(sphereWorld, _camera.View, _camera.Projection));
+
+        Game.SpriteBatch.Begin(SpriteSortMode.BackToFront, BlendState.Opaque, SamplerState.PointClamp,
+            DepthStencilState.Default, RasterizerState.CullCounterClockwise);
+        Game.SpriteBatch.DrawString(_spriteFont, "Box handled: " + count + ".",
+            new Vector2(GraphicsDevice.Viewport.Width - 500, 0), Color.White);
+        Game.SpriteBatch.DrawString(_spriteFont, "Launch spheres with the 'Z' key.",
+            new Vector2(GraphicsDevice.Viewport.Width - 500, 25), Color.White);
+        Game.SpriteBatch.End();
+
+        base.Draw(gameTime);
+    }
+
+    protected override void UnloadContent()
+    {
+        _simulation?.Dispose();
+        _simulation = null;
+        _bufferPool.Clear();
+        _threadDispatcher.Dispose();
+
+        base.UnloadContent();
     }
 }

--- a/TGC.MonoGame.Samples/Samples/Physics/BEPU/WallOfBoxes.cs
+++ b/TGC.MonoGame.Samples/Samples/Physics/BEPU/WallOfBoxes.cs
@@ -14,250 +14,250 @@ using TGC.MonoGame.Samples.Physics.Bepu;
 using TGC.MonoGame.Samples.Viewer;
 using NumericVector3 = System.Numerics.Vector3;
 
-namespace TGC.MonoGame.Samples.Samples.Physics.Bepu
+namespace TGC.MonoGame.Samples.Samples.Physics.Bepu;
+
+/// <summary>
+///     Wall Of Boxes:
+///     Sample of how to use the Bepu physics engine with simple geometries.
+///     Authors: Leandro Javier Laiño, Rodrigo Nicolás Garcia, Ronán Ariel Vinitzca.
+/// </summary>
+public class WallOfBoxes : TGCSample
 {
+    private BoxPrimitive _box;
+    private List<Matrix> _boxesWorld;
+    private List<BodyHandle> _boxHandles;
+
     /// <summary>
-    ///     Wall Of Boxes:
-    ///     Sample of how to use the Bepu physics engine with simple geometries.
-    ///     Authors: Leandro Javier Laiño, Rodrigo Nicolás Garcia, Ronán Ariel Vinitzca.
+    ///     Gets the buffer pool used by the demo's simulation.
+    ///     Note that the buffer pool used by the simulation is not considered to be *owned* by the simulation.
+    ///     The simulation merely uses the pool.
+    ///     Disposing the simulation will not dispose or clear the buffer pool.
     /// </summary>
-    public class WallOfBoxes : TGCSample
+    private BufferPool _bufferPool;
+
+    private Camera _camera;
+    private bool _canShoot;
+    private QuadPrimitive _floor;
+    private Matrix _floorWorld;
+    private List<float> _radii;
+
+    /// <summary>
+    ///     We'll randomize the size of bullets.
+    /// </summary>
+    private Random _random;
+
+    /// <summary>
+    ///     Gets the simulation created by the sample's Initialize call.
+    /// </summary>
+    private Simulation _simulation;
+
+    private SpherePrimitive _sphere;
+    private List<BodyHandle> _sphereHandles;
+    private List<Matrix> _spheresWorld;
+    private SpriteFont _spriteFont;
+
+    /// <summary>
+    ///     Gets the thread dispatcher available for use by the simulation.
+    /// </summary>
+    private SimpleThreadDispatcher _threadDispatcher;
+
+    private Effect _tilingEffect;
+
+    /// <inheritdoc />
+    public WallOfBoxes(TGCViewer game) : base(game)
     {
-        /// <inheritdoc />
-        public WallOfBoxes(TGCViewer game) : base(game)
+        Category = TGCSampleCategory.Physics;
+        Name = "BepuPhysics - Wall of boxes";
+        Description = "Time to drop boxes!";
+    }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        _canShoot = true;
+
+        base.Initialize();
+    }
+
+    /// <inheritdoc />
+    protected override void LoadContent()
+    {
+        _random = new Random(5);
+
+        _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
+
+        //The buffer pool is a source of raw memory blobs for the engine to use.
+        _bufferPool = new BufferPool();
+
+        _radii = new List<float>();
+        _camera = new SimpleCamera(GraphicsDevice.Viewport.AspectRatio, new Vector3(40, 60, 150), 55, 0.4f);
+
+        var boxTexture = Game.Content.Load<Texture2D>(ContentFolderTextures + "wood/caja-madera-3");
+        _box = new BoxPrimitive(GraphicsDevice, Vector3.One * 10, boxTexture);
+
+        _sphere = new SpherePrimitive(GraphicsDevice);
+
+        _sphereHandles = new List<BodyHandle>();
+        _boxHandles = new List<BodyHandle>();
+
+        var targetThreadCount = Math.Max(1,
+            Environment.ProcessorCount > 4 ? Environment.ProcessorCount - 2 : Environment.ProcessorCount - 1);
+        _threadDispatcher = new SimpleThreadDispatcher(targetThreadCount);
+
+        // This are meshes/model/primitives collections to render
+        // The PositionFirstTimestepper is the simplest timestepping mode, but since it integrates velocity into position at the start of the frame, directly modified velocities outside of the timestep
+        // will be integrated before collision detection or the solver has a chance to intervene. That's fine in this demo. Other built-in options include the PositionLastTimestepper and the SubsteppingTimestepper.
+        // Note that the timestepper also has callbacks that you can use for executing logic between processing stages, like BeforeCollisionDetection.
+        _simulation = Simulation.Create(_bufferPool,
+            new NarrowPhaseCallbacks(new SpringSettings(30, 1)),
+            new PoseIntegratorCallbacks(new NumericVector3(0, -100, 0)),
+            new SolveDescription(8, 1));
+
+        // Creates a floor
+        var floorTexture = Game.Content.Load<Texture2D>(ContentFolderTextures + "floor/adoquin-2");
+        _floor = new QuadPrimitive(GraphicsDevice);
+
+        _tilingEffect = Game.Content.Load<Effect>(ContentFolderEffects + "TextureTiling");
+        _tilingEffect.Parameters["Texture"].SetValue(floorTexture);
+        _tilingEffect.Parameters["Tiling"].SetValue(Vector2.One * 50f);
+
+        _floorWorld = Matrix.CreateScale(400f) * Matrix.CreateTranslation(new Vector3(75, 0, -150));
+        _simulation.Statics.Add(new StaticDescription(new NumericVector3(0, -0.5f, 0),
+            _simulation.Shapes.Add(new Box(2000, 1, 2000))));
+
+        _boxesWorld = new List<Matrix>();
+        _spheresWorld = new List<Matrix>();
+
+        // Single Box
+        var radius = 10;
+        for (var j = 0; j < 5; j++)
         {
-            Category = TGCSampleCategory.Physics;
-            Name = "BepuPhysics - Wall of boxes";
-            Description = "Time to drop boxes!";
-        }
-
-        private QuadPrimitive _floor;
-        private Matrix _floorWorld;
-        private BoxPrimitive _box;
-
-        /// <summary>
-        ///     We'll randomize the size of bullets.
-        /// </summary>
-        private Random _random;
-
-        private SpherePrimitive _sphere;
-        private List<float> _radii;
-        private List<BodyHandle> _sphereHandles;
-        private List<BodyHandle> _boxHandles;
-        private List<Matrix> _boxesWorld;
-        private List<Matrix> _spheresWorld;
-        private bool _canShoot;
-
-        private Effect _tilingEffect;
-
-        /// <summary>
-        ///     Gets the buffer pool used by the demo's simulation.
-        ///     Note that the buffer pool used by the simulation is not considered to be *owned* by the simulation.
-        ///     The simulation merely uses the pool.
-        ///     Disposing the simulation will not dispose or clear the buffer pool.
-        /// </summary>
-        private BufferPool _bufferPool;
-
-        private Camera _camera;
-
-        /// <summary>
-        ///     Gets the simulation created by the sample's Initialize call.
-        /// </summary>
-        private Simulation _simulation;
-
-        private SpriteFont _spriteFont;
-
-        /// <summary>
-        ///     Gets the thread dispatcher available for use by the simulation.
-        /// </summary>
-        private SimpleThreadDispatcher _threadDispatcher;
-
-        /// <inheritdoc />
-        public override void Initialize()
-        {
-            _canShoot = true;
-
-            base.Initialize();
-        }
-
-        /// <inheritdoc />
-        protected override void LoadContent()
-        {
-            _random = new Random(5);
-
-            _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
-            
-            //The buffer pool is a source of raw memory blobs for the engine to use.
-            _bufferPool = new BufferPool();
-
-            _radii = new List<float>();
-            _camera = new SimpleCamera(GraphicsDevice.Viewport.AspectRatio, new Vector3(40, 60, 150), 55, 0.4f);
-
-            var boxTexture = Game.Content.Load<Texture2D>(ContentFolderTextures + "wood/caja-madera-3");
-            _box = new BoxPrimitive(GraphicsDevice, Vector3.One * 10, boxTexture);
-
-            _sphere = new SpherePrimitive(GraphicsDevice);
-
-            _sphereHandles = new List<BodyHandle>();
-            _boxHandles = new List<BodyHandle>();
-
-            var targetThreadCount = Math.Max(1,
-                Environment.ProcessorCount > 4 ? Environment.ProcessorCount - 2 : Environment.ProcessorCount - 1);
-            _threadDispatcher = new SimpleThreadDispatcher(targetThreadCount);
-
-            // This are meshes/model/primitives collections to render
-            // The PositionFirstTimestepper is the simplest timestepping mode, but since it integrates velocity into position at the start of the frame, directly modified velocities outside of the timestep
-            // will be integrated before collision detection or the solver has a chance to intervene. That's fine in this demo. Other built-in options include the PositionLastTimestepper and the SubsteppingTimestepper.
-            // Note that the timestepper also has callbacks that you can use for executing logic between processing stages, like BeforeCollisionDetection.
-            _simulation = Simulation.Create(_bufferPool,
-                new NarrowPhaseCallbacks(new SpringSettings(30, 1)),
-                new PoseIntegratorCallbacks(new NumericVector3(0, -100, 0)),
-                new SolveDescription(8, 1));
-
-            // Creates a floor
-            var floorTexture = Game.Content.Load<Texture2D>(ContentFolderTextures + "floor/adoquin-2");
-            _floor = new QuadPrimitive(GraphicsDevice);
-
-            _tilingEffect = Game.Content.Load<Effect>(ContentFolderEffects + "TextureTiling");
-            _tilingEffect.Parameters["Texture"].SetValue(floorTexture);
-            _tilingEffect.Parameters["Tiling"].SetValue(Vector2.One * 50f);
-
-            _floorWorld = Matrix.CreateScale(400f) * Matrix.CreateTranslation(new Vector3(75,0, -150));
-            _simulation.Statics.Add(new StaticDescription(new NumericVector3(0, -0.5f, 0),
-                _simulation.Shapes.Add(new Box(2000, 1, 2000))));
-
-            _boxesWorld = new List<Matrix>();
-            _spheresWorld = new List<Matrix>();
-
-            // Single Box
-            var radius = 10;
-            for (var j = 0; j < 5; j++)
+            for (var i = 0; i < 20; i++)
             {
-                for (var i = 0; i < 20; i++)
-                {
-                    var boxShape = new Box(radius, radius, radius);
-                    var boxInertia = boxShape.ComputeInertia(0.4f);
-                    var boxIndex = _simulation.Shapes.Add(boxShape);
-                    var position = new NumericVector3(-30 + i * 10 + 1, j * 10 + 1, -40);
+                var boxShape = new Box(radius, radius, radius);
+                var boxInertia = boxShape.ComputeInertia(0.4f);
+                var boxIndex = _simulation.Shapes.Add(boxShape);
+                var position = new NumericVector3(-30 + i * 10 + 1, j * 10 + 1, -40);
 
-                    var bodyDescription = BodyDescription.CreateDynamic(position, boxInertia, 
-                        new CollidableDescription(boxIndex, 0.1f), new BodyActivityDescription(0.01f));
-
-                    var bodyHandle = _simulation.Bodies.Add(bodyDescription);
-
-                    _boxHandles.Add(bodyHandle);
-                }
-            }
-
-            base.LoadContent();
-        }
-
-        /// <inheritdoc />
-        public override void Update(GameTime gameTime)
-        {
-            // In the demos, we use one time step per frame. We don't bother modifying the physics time step duration for different monitors so different refresh rates
-            // change the rate of simulation. This doesn't actually change the result of the simulation, though, and the simplicity is a good fit for the demos.
-            // In the context of a 'real' application, you could instead use a time accumulator to take time steps of fixed length as needed, or
-            // fully decouple simulation and rendering rates across different threads.
-            // (In either case, you'd also want to interpolate or extrapolate simulation results during rendering for smoothness.)
-            // Note that taking steps of variable length can reduce stability. Gradual or one-off changes can work reasonably well.
-            _simulation.Timestep(1 / 60f, _threadDispatcher);
-            _camera.Update(gameTime);
-
-            if (Game.CurrentKeyboardState.IsKeyDown(Keys.Z) && _canShoot)
-            {
-                _canShoot = false;
-                // Create the shape that we'll launch at the pyramids when the user presses a button.
-                var radius = 0.5f + 5 * (float) _random.NextDouble();
-                var bulletShape = new Sphere(radius);
-
-                // Note that the use of radius^3 for mass can produce some pretty serious mass ratios. 
-                // Observe what happens when a large ball sits on top of a few boxes with a fraction of the mass-
-                // the collision appears much squishier and less stable. For most games, if you want to maintain rigidity, you'll want to use some combination of:
-                // 1) Limit the ratio of heavy object masses to light object masses when those heavy objects depend on the light objects.
-                // 2) Use a shorter timestep duration and update more frequently.
-                // 3) Use a greater number of solver iterations.
-                // #2 and #3 can become very expensive. In pathological cases, it can end up slower than using a quality-focused solver for the same simulation.
-                // Unfortunately, at the moment, bepuphysics v2 does not contain any alternative solvers, so if you can't afford to brute force the the problem away,
-                // the best solution is to cheat as much as possible to avoid the corner cases.
-                var position = new NumericVector3(-40 + 210 * (float) _random.NextDouble(), 130, 130);
-                var bodyDescription = BodyDescription.CreateConvexDynamic(position,
-                    new BodyVelocity(new NumericVector3((float) _random.NextDouble(), 0, -110)),
-                    bulletShape.Radius * bulletShape.Radius * bulletShape.Radius, _simulation.Shapes, bulletShape);
+                var bodyDescription = BodyDescription.CreateDynamic(position, boxInertia,
+                    new CollidableDescription(boxIndex, 0.1f), new BodyActivityDescription(0.01f));
 
                 var bodyHandle = _simulation.Bodies.Add(bodyDescription);
 
-                _radii.Add(radius);
-                _sphereHandles.Add(bodyHandle);
+                _boxHandles.Add(bodyHandle);
             }
-
-            if (Game.CurrentKeyboardState.IsKeyUp(Keys.Z)) 
-                _canShoot = true;
-
-
-            _boxesWorld.Clear();
-            var boxHandleCount = _boxHandles.Count;
-            for (var index = 0; index < boxHandleCount; index++)
-            {
-                var pose = _simulation.Bodies.GetBodyReference(_boxHandles[index]).Pose;
-                var position = pose.Position;
-                var quaternion = pose.Orientation;
-                var world =
-                    Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
-                        quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
-                _boxesWorld.Add(world);
-            }
-
-            _spheresWorld.Clear();
-            var sphereHandleCount = _sphereHandles.Count;
-            for (var index = 0; index < sphereHandleCount; index++)
-            {
-                var pose = _simulation.Bodies.GetBodyReference(_sphereHandles[index]).Pose;
-                var position = pose.Position;
-                var quaternion = pose.Orientation;
-                var world = Matrix.CreateScale(_radii[index]) *
-                            Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
-                                quaternion.W)) *
-                            Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
-                _spheresWorld.Add(world);
-            }
-
-            Game.Gizmos.UpdateViewProjection(_camera.View, _camera.Projection);
-
-            base.Update(gameTime);
         }
 
-        /// <inheritdoc />
-        public override void Draw(GameTime gameTime)
+        base.LoadContent();
+    }
+
+    /// <inheritdoc />
+    public override void Update(GameTime gameTime)
+    {
+        // In the demos, we use one time step per frame. We don't bother modifying the physics time step duration for different monitors so different refresh rates
+        // change the rate of simulation. This doesn't actually change the result of the simulation, though, and the simplicity is a good fit for the demos.
+        // In the context of a 'real' application, you could instead use a time accumulator to take time steps of fixed length as needed, or
+        // fully decouple simulation and rendering rates across different threads.
+        // (In either case, you'd also want to interpolate or extrapolate simulation results during rendering for smoothness.)
+        // Note that taking steps of variable length can reduce stability. Gradual or one-off changes can work reasonably well.
+        _simulation.Timestep(1 / 60f, _threadDispatcher);
+        _camera.Update(gameTime);
+
+        if (Game.CurrentKeyboardState.IsKeyDown(Keys.Z) && _canShoot)
         {
-            Game.Background = Color.Black;
-            GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+            _canShoot = false;
+            // Create the shape that we'll launch at the pyramids when the user presses a button.
+            var radius = 0.5f + 5 * (float)_random.NextDouble();
+            var bulletShape = new Sphere(radius);
 
-            _tilingEffect.Parameters["WorldViewProjection"].SetValue(_floorWorld * _camera.View * _camera.Projection);
-            _floor.Draw(_tilingEffect);
-            _boxesWorld.ForEach(boxWorld => _box.Draw(boxWorld, _camera.View, _camera.Projection));
-            _spheresWorld.ForEach(sphereWorld => _sphere.Draw(sphereWorld, _camera.View, _camera.Projection));
+            // Note that the use of radius^3 for mass can produce some pretty serious mass ratios. 
+            // Observe what happens when a large ball sits on top of a few boxes with a fraction of the mass-
+            // the collision appears much squishier and less stable. For most games, if you want to maintain rigidity, you'll want to use some combination of:
+            // 1) Limit the ratio of heavy object masses to light object masses when those heavy objects depend on the light objects.
+            // 2) Use a shorter timestep duration and update more frequently.
+            // 3) Use a greater number of solver iterations.
+            // #2 and #3 can become very expensive. In pathological cases, it can end up slower than using a quality-focused solver for the same simulation.
+            // Unfortunately, at the moment, bepuphysics v2 does not contain any alternative solvers, so if you can't afford to brute force the the problem away,
+            // the best solution is to cheat as much as possible to avoid the corner cases.
+            var position = new NumericVector3(-40 + 210 * (float)_random.NextDouble(), 130, 130);
+            var bodyDescription = BodyDescription.CreateConvexDynamic(position,
+                new BodyVelocity(new NumericVector3((float)_random.NextDouble(), 0, -110)),
+                bulletShape.Radius * bulletShape.Radius * bulletShape.Radius, _simulation.Shapes, bulletShape);
 
-            Game.SpriteBatch.Begin(SpriteSortMode.BackToFront, BlendState.Opaque, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
-            Game.SpriteBatch.DrawString(_spriteFont, "Launch spheres with the 'Z' key.", new Vector2(GraphicsDevice.Viewport.Width - 500, 0), Color.White);
-            Game.SpriteBatch.End();
-            
-            base.Draw(gameTime);
+            var bodyHandle = _simulation.Bodies.Add(bodyDescription);
+
+            _radii.Add(radius);
+            _sphereHandles.Add(bodyHandle);
         }
 
-        /// <inheritdoc />
-        protected override void UnloadContent()
+        if (Game.CurrentKeyboardState.IsKeyUp(Keys.Z))
         {
-            // If you intend to reuse the BufferPool, disposing the simulation is a good idea- it returns all the buffers to the pool for reuse.
-            // Here, we dispose it, but it's not really required; we immediately thereafter clear the BufferPool of all held memory.
-            // Note that failing to dispose buffer pools can result in memory leaks.
-            _simulation.Dispose();
-
-            _bufferPool.Clear();
-
-            _threadDispatcher.Dispose();
-
-            base.UnloadContent();
+            _canShoot = true;
         }
+
+        _boxesWorld.Clear();
+        var boxHandleCount = _boxHandles.Count;
+        for (var index = 0; index < boxHandleCount; index++)
+        {
+            var pose = _simulation.Bodies.GetBodyReference(_boxHandles[index]).Pose;
+            var position = pose.Position;
+            var quaternion = pose.Orientation;
+            var world =
+                Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
+                    quaternion.W)) * Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
+            _boxesWorld.Add(world);
+        }
+
+        _spheresWorld.Clear();
+        var sphereHandleCount = _sphereHandles.Count;
+        for (var index = 0; index < sphereHandleCount; index++)
+        {
+            var pose = _simulation.Bodies.GetBodyReference(_sphereHandles[index]).Pose;
+            var position = pose.Position;
+            var quaternion = pose.Orientation;
+            var world = Matrix.CreateScale(_radii[index]) *
+                        Matrix.CreateFromQuaternion(new Quaternion(quaternion.X, quaternion.Y, quaternion.Z,
+                            quaternion.W)) *
+                        Matrix.CreateTranslation(new Vector3(position.X, position.Y, position.Z));
+            _spheresWorld.Add(world);
+        }
+
+        Game.Gizmos.UpdateViewProjection(_camera.View, _camera.Projection);
+
+        base.Update(gameTime);
+    }
+
+    /// <inheritdoc />
+    public override void Draw(GameTime gameTime)
+    {
+        Game.Background = Color.Black;
+        GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+
+        _tilingEffect.Parameters["WorldViewProjection"].SetValue(_floorWorld * _camera.View * _camera.Projection);
+        _floor.Draw(_tilingEffect);
+        _boxesWorld.ForEach(boxWorld => _box.Draw(boxWorld, _camera.View, _camera.Projection));
+        _spheresWorld.ForEach(sphereWorld => _sphere.Draw(sphereWorld, _camera.View, _camera.Projection));
+
+        Game.SpriteBatch.Begin(SpriteSortMode.BackToFront, BlendState.Opaque, SamplerState.PointClamp,
+            DepthStencilState.Default, RasterizerState.CullCounterClockwise);
+        Game.SpriteBatch.DrawString(_spriteFont, "Launch spheres with the 'Z' key.",
+            new Vector2(GraphicsDevice.Viewport.Width - 500, 0), Color.White);
+        Game.SpriteBatch.End();
+
+        base.Draw(gameTime);
+    }
+
+    /// <inheritdoc />
+    protected override void UnloadContent()
+    {
+        // If you intend to reuse the BufferPool, disposing the simulation is a good idea- it returns all the buffers to the pool for reuse.
+        // Here, we dispose it, but it's not really required; we immediately thereafter clear the BufferPool of all held memory.
+        // Note that failing to dispose buffer pools can result in memory leaks.
+        _simulation?.Dispose();
+        _simulation = null;
+        _bufferPool.Clear();
+        _threadDispatcher.Dispose();
+
+        base.UnloadContent();
     }
 }


### PR DESCRIPTION
Fix #103.

Agregue

```C#
_simulation?.Dispose();
_simulation = null;
```

En UnloadContent, el problema era que cuando se cambia de ejemplo se hace unloadcontent y al final cuando se cierra el Viewer el hace un unload de todos los componentes (los samples son componentes) y el segundo Dispose a Bepu no le gusta 😆.

El resto de los cambios es el codeclean de Rider 😝.