### PR TITLE
New backface culling example

### DIFF
--- a/TGC.MonoGame.Samples/Content/Content.mgcb
+++ b/TGC.MonoGame.Samples/Content/Content.mgcb
@@ -12,17 +12,6 @@
 
 
 #---------------------------------- Content ---------------------------------#
-#begin Effects/Deferred.fx
-/importer:EffectImporter
-/processor:EffectProcessor
-/processorParam:DebugMode=Auto
-/build:Effects/Deferred.fx
-
-#begin Effects/DeferredModel.fx
-/importer:EffectImporter
-/processor:EffectProcessor
-/processorParam:DebugMode=Auto
-/build:Effects/DeferredModel.fx
 
 #begin 3D/chair/chair.fbx
 /importer:FbxImporter
@@ -268,11 +257,30 @@
 /processorParam:DebugMode=Auto
 /build:Effects/DebugTexture.fx
 
+#begin Effects/Deferred.fx
+/importer:EffectImporter
+/processor:EffectProcessor
+/processorParam:DebugMode=Auto
+/build:Effects/Deferred.fx
+
+#begin Effects/DeferredModel.fx
+/importer:EffectImporter
+/processor:EffectProcessor
+/processorParam:DebugMode=Auto
+/build:Effects/DeferredModel.fx
+
 #begin Effects/EnvironmentMap.fx
 /importer:EffectImporter
 /processor:EffectProcessor
 /processorParam:DebugMode=Auto
 /build:Effects/EnvironmentMap.fx
+
+#begin Effects/ExplodeColored.fx
+/importer:EffectImporter
+/processor:EffectProcessor
+/processorParam:DebugMode=Auto
+/processorParam:Defines=
+/build:Effects/ExplodeColored.fx
 
 #begin Effects/GaussianBlur.fx
 /importer:EffectImporter
@@ -1103,3 +1111,4 @@
 /processorParam:MakeSquare=False
 /processorParam:TextureFormat=Color
 /build:Textures/wood/caja-madera-4.jpg
+

--- a/TGC.MonoGame.Samples/Content/Effects/ExplodeColored.fx
+++ b/TGC.MonoGame.Samples/Content/Effects/ExplodeColored.fx
@@ -1,0 +1,63 @@
+#if OPENGL
+	#define SV_POSITION POSITION
+	#define VS_SHADERMODEL vs_3_0
+	#define PS_SHADERMODEL ps_3_0
+#else
+	#define VS_SHADERMODEL vs_4_0_level_9_1
+	#define PS_SHADERMODEL ps_4_0_level_9_1
+#endif
+
+float4x4 ViewProjection;
+float4x4 World;
+
+struct VertexShaderInput
+{
+	float4 Position : POSITION0;
+    float3 Normal : NORMAL0;
+    float4 Color : COLOR0;
+};
+
+struct VertexShaderOutput
+{
+	float4 Position : SV_POSITION;
+    float3 Normal : TEXCOORD3;
+    float4 Color : COLOR0;
+};
+
+texture ModelTexture;
+sampler2D textureSampler = sampler_state
+{
+    Texture = (ModelTexture);
+    MagFilter = Linear;
+    MinFilter = Linear;
+    AddressU = Clamp;
+    AddressV = Clamp;
+};
+
+VertexShaderOutput MainVS(in VertexShaderInput input)
+{
+	VertexShaderOutput output = (VertexShaderOutput)0;
+
+    // Displace vertex along its normal to create an explosion effect
+    input.Position += float4(input.Normal * 2, 0.0);
+
+    output.Position = mul(input.Position, mul(World, ViewProjection));
+    output.Normal = input.Normal;
+    output.Color = input.Color;
+
+    return output;
+}
+
+float4 MainPS(VertexShaderOutput input) : COLOR
+{
+    return input.Color;
+}
+
+technique DefaultTechnique
+{
+	pass P0
+	{
+		VertexShader = compile VS_SHADERMODEL MainVS();
+		PixelShader = compile PS_SHADERMODEL MainPS();
+	}
+};

--- a/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
+++ b/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
@@ -59,6 +59,8 @@ public class BackfaceCullingCube : TGCSample
     public override void Update(GameTime gameTime)
     {
         var totalTime = (float)gameTime.TotalGameTime.TotalSeconds;
+
+        // A simple repeating rotation cycle to show all faces of the cube.
         _rotation = Quaternion.CreateFromYawPitchRoll(MathF.Sin(totalTime), MathF.Cos(totalTime), MathF.Sin(MathF.Abs(totalTime)));
         Game.Gizmos.UpdateViewProjection(_camera.View, _camera.Projection);
 
@@ -72,11 +74,25 @@ public class BackfaceCullingCube : TGCSample
         _effect.Parameters["ViewProjection"].SetValue(_camera.View * _camera.Projection);
 
         var existingRasterizerState = GraphicsDevice.RasterizerState;
+
+        // Draw the cube with different culling modes, separated by a <step> offset along the X-axis.
         var step = 35f;
         var offset = -step;
         foreach (var cullMode in _cullModes)
         {
-            GraphicsDevice.RasterizerState = new RasterizerState { CullMode = cullMode, FillMode = _wireframeEnabled ? FillMode.WireFrame : FillMode.Solid };
+            /*
+                Create a new rasterizer state and set the desired values for this draw call.
+                we need to have a different RasterizerState because once it has been binded to the gpu it cannot be modified.
+                in a real application you would want to cache the different rasterizer states and reuse them instead of creating new ones every frame.
+                Reference:
+                    https://docs.monogame.net/articles/getting_to_know/whatis/graphics/WhatIs_Rasterizer.html
+                    https://www.tgcutn.com.ar/material/notes/unit3
+            */
+            GraphicsDevice.RasterizerState = new RasterizerState
+            {
+                CullMode = cullMode,    // Set the culling mode for this draw call
+                FillMode = _wireframeEnabled ? FillMode.WireFrame : FillMode.Solid,
+            };
             var world = Matrix.CreateFromQuaternion(_rotation) * Matrix.CreateTranslation(offset, 0f, 0f);
             _effect.Parameters["World"].SetValue(world);
             _cube.Draw(_effect);
@@ -105,12 +121,14 @@ public class BackfaceCullingCube : TGCSample
     protected override void UnloadContent()
     {
         _cube.Dispose();
-
         _effect.Dispose();
         _spriteFont.Texture.Dispose();
         base.UnloadContent();
     }
 
+    /// <summary>
+    /// Draws the labels for each culling mode.
+    /// </summary>
     private void DrawLabels()
     {
         // Draw labels

--- a/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
+++ b/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using TGC.MonoGame.Samples.Cameras;
+using TGC.MonoGame.Samples.Geometries;
+using TGC.MonoGame.Samples.Viewer;
+
+namespace TGC.MonoGame.Samples.Samples.RenderPipeline;
+
+/// <summary>
+///     Default example with TGC logo.
+/// </summary>
+public class BackfaceCullingCube : TGCSample
+{
+    private readonly List<RasterizerState> _rasterizerStates = new List<RasterizerState>
+    {
+        new RasterizerState { CullMode = CullMode.CullClockwiseFace },
+        new RasterizerState { CullMode = CullMode.None },
+        new RasterizerState { CullMode = CullMode.CullCounterClockwiseFace },
+    };
+
+    private Quaternion _rotation = Quaternion.Identity;
+
+    // The following fields are initialized in LoadContent, so they are marked as non-nullable with the null-forgiving operator (!).
+    private Camera _camera = null!;
+
+    private CubePrimitive _cube = null!;
+
+    private Effect _effect = null!;
+
+    private SpriteFont _spriteFont = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BackfaceCullingCube"/> class.
+    ///     Default constructor.
+    /// </summary>
+    /// <param name="game">The game.</param>
+    public BackfaceCullingCube(TGCViewer game)
+        : base(game)
+    {
+        Name = "Back-Face Culling Cube";
+        Description = Description = "Visualize the back-face culling command";
+        Category = TGCSampleCategory.RenderPipeline;
+    }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        _camera = new TargetCamera(GraphicsDevice.Viewport.AspectRatio, Vector3.UnitZ * 150, Vector3.UnitZ);
+        base.Initialize();
+    }
+
+    /// <inheritdoc />
+    protected override void LoadContent()
+    {
+        // Load mesh.
+        _cube = new CubePrimitive(GraphicsDevice, 10f, Color.Red, Color.Green, Color.Blue, Color.Yellow, Color.Cyan, Color.Magenta);
+        _effect = Game.Content.Load<Effect>(ContentFolderEffects + "ExplodeColored");
+        _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
+        ModifierController.AddToggle("Show Wireframe", (enabled) => HandleWireframeToggle(enabled), false);
+        base.LoadContent();
+    }
+
+    /// <inheritdoc />
+    protected override void UnloadContent()
+    {
+        _cube.Dispose();
+        foreach (var rs in _rasterizerStates)
+        {
+            rs.Dispose();
+        }
+
+        _effect.Dispose();
+        _spriteFont.Texture.Dispose();
+        base.UnloadContent();
+    }
+
+    /// <inheritdoc />
+    public override void Update(GameTime gameTime)
+    {
+        var totalTime = (float)gameTime.TotalGameTime.TotalSeconds;
+        _rotation = Quaternion.CreateFromYawPitchRoll(MathF.Sin(totalTime), MathF.Cos(totalTime), MathF.Sin(MathF.Abs(totalTime)));
+        Game.Gizmos.UpdateViewProjection(_camera.View, _camera.Projection);
+
+        base.Update(gameTime);
+    }
+
+    /// <inheritdoc />
+    public override void Draw(GameTime gameTime)
+    {
+        Game.Background = Color.Black;
+        _effect.Parameters["ViewProjection"].SetValue(_camera.View * _camera.Projection);
+
+        var existingRasterizerState = GraphicsDevice.RasterizerState;
+        var step = 35f;
+        var offset = -step;
+        foreach (var rs in _rasterizerStates)
+        {
+            GraphicsDevice.RasterizerState = rs;
+            var world = Matrix.CreateFromQuaternion(_rotation) * Matrix.CreateTranslation(offset, 0f, 0f);
+            _effect.Parameters["World"].SetValue(world);
+            _cube.Draw(_effect);
+            offset += step;
+        }
+
+        // Always restore the previous rasterizer state after drawing
+        GraphicsDevice.RasterizerState = existingRasterizerState;
+
+        DrawLabels();
+        base.Draw(gameTime);
+    }
+
+    private void HandleWireframeToggle(bool enabled)
+    {
+        for (int i = 0; i < _rasterizerStates.Count; i++)
+        {
+            var oldRs = _rasterizerStates[i];
+            var newRs = new RasterizerState
+            {
+                CullMode = oldRs.CullMode,
+                FillMode = enabled ? FillMode.WireFrame : FillMode.Solid,
+            };
+            _rasterizerStates[i] = newRs;
+        }
+    }
+
+    private void DrawLabels()
+    {
+        // Draw labels
+        Game.SpriteBatch.Begin(
+            SpriteSortMode.Immediate,
+            BlendState.AlphaBlend,
+            SamplerState.LinearClamp,
+            DepthStencilState.Default,
+            RasterizerState.CullNone);
+
+        var step = 35f;
+        var offset = -step;
+        foreach (var rs in _rasterizerStates)
+        {
+            string label = rs.CullMode switch
+            {
+                CullMode.CullClockwiseFace => "Cull Clockwise",
+                CullMode.None => "No Culling",
+                CullMode.CullCounterClockwiseFace => "Cull Counter-Clockwise",
+                _ => "Unknown",
+            };
+
+            var size = _spriteFont.MeasureString(label) / 2f;
+            var projectedPosition = GraphicsDevice.Viewport.Project(
+                    new Vector3(offset, -20f, 0f), _camera.Projection, _camera.View, Matrix.Identity);
+
+            var textPosition = new Vector2(projectedPosition.X, projectedPosition.Y) - size;
+
+            Game.SpriteBatch.DrawString(_spriteFont, label, textPosition, Color.White);
+
+            offset += step;
+        }
+
+        Game.SpriteBatch.End();
+    }
+}

--- a/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
+++ b/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
@@ -23,6 +23,7 @@ public class BackfaceCullingCube : TGCSample
     ];
 
     private Quaternion _rotation = Quaternion.Identity;
+    private bool _wireframeEnabled;
 
     // The following fields are initialized in LoadContent, so they are marked as non-nullable with the null-forgiving operator (!).
     private Camera _camera = null!;
@@ -32,8 +33,6 @@ public class BackfaceCullingCube : TGCSample
     private Effect _effect = null!;
 
     private SpriteFont _spriteFont = null!;
-
-    private bool _wireframeEnabled;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BackfaceCullingCube"/> class.
@@ -71,8 +70,11 @@ public class BackfaceCullingCube : TGCSample
     public override void Draw(GameTime gameTime)
     {
         Game.Background = Color.Black;
+        DrawLabels();
         _effect.Parameters["ViewProjection"].SetValue(_camera.View * _camera.Projection);
 
+        // Save current rasterizer state to restore it later.
+        // We don't know if there's other code that assumes a default rasterizer state down the line.
         var existingRasterizerState = GraphicsDevice.RasterizerState;
 
         // Draw the cube with different culling modes, separated by a <step> offset along the X-axis.
@@ -93,16 +95,21 @@ public class BackfaceCullingCube : TGCSample
                 CullMode = cullMode,    // Set the culling mode for this draw call
                 FillMode = _wireframeEnabled ? FillMode.WireFrame : FillMode.Solid,
             };
+
             var world = Matrix.CreateFromQuaternion(_rotation) * Matrix.CreateTranslation(offset, 0f, 0f);
             _effect.Parameters["World"].SetValue(world);
             _cube.Draw(_effect);
             offset += step;
         }
 
-        // Always restore the previous rasterizer state after drawing
+        /*
+            Always restore the previous rasterizer state after drawing.
+            To see an example of what happens if you don't restore it,
+            uncomment the following line, run the sample, check "Show wireframes"
+            and look at what happens to the gizmos.
+        */
         GraphicsDevice.RasterizerState = existingRasterizerState;
 
-        DrawLabels();
         base.Draw(gameTime);
     }
 
@@ -131,7 +138,6 @@ public class BackfaceCullingCube : TGCSample
     /// </summary>
     private void DrawLabels()
     {
-        // Draw labels
         Game.SpriteBatch.Begin(
             SpriteSortMode.Immediate,
             BlendState.AlphaBlend,

--- a/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
+++ b/TGC.MonoGame.Samples/Samples/RenderPipeline/BackfaceCullingCube.cs
@@ -15,12 +15,12 @@ namespace TGC.MonoGame.Samples.Samples.RenderPipeline;
 /// </summary>
 public class BackfaceCullingCube : TGCSample
 {
-    private readonly List<RasterizerState> _rasterizerStates = new List<RasterizerState>
-    {
-        new RasterizerState { CullMode = CullMode.CullClockwiseFace },
-        new RasterizerState { CullMode = CullMode.None },
-        new RasterizerState { CullMode = CullMode.CullCounterClockwiseFace },
-    };
+    private readonly List<CullMode> _cullModes =
+    [
+        CullMode.CullClockwiseFace,
+        CullMode.None,
+        CullMode.CullCounterClockwiseFace,
+    ];
 
     private Quaternion _rotation = Quaternion.Identity;
 
@@ -32,6 +32,8 @@ public class BackfaceCullingCube : TGCSample
     private Effect _effect = null!;
 
     private SpriteFont _spriteFont = null!;
+
+    private bool _wireframeEnabled;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BackfaceCullingCube"/> class.
@@ -54,31 +56,6 @@ public class BackfaceCullingCube : TGCSample
     }
 
     /// <inheritdoc />
-    protected override void LoadContent()
-    {
-        // Load mesh.
-        _cube = new CubePrimitive(GraphicsDevice, 10f, Color.Red, Color.Green, Color.Blue, Color.Yellow, Color.Cyan, Color.Magenta);
-        _effect = Game.Content.Load<Effect>(ContentFolderEffects + "ExplodeColored");
-        _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
-        ModifierController.AddToggle("Show Wireframe", (enabled) => HandleWireframeToggle(enabled), false);
-        base.LoadContent();
-    }
-
-    /// <inheritdoc />
-    protected override void UnloadContent()
-    {
-        _cube.Dispose();
-        foreach (var rs in _rasterizerStates)
-        {
-            rs.Dispose();
-        }
-
-        _effect.Dispose();
-        _spriteFont.Texture.Dispose();
-        base.UnloadContent();
-    }
-
-    /// <inheritdoc />
     public override void Update(GameTime gameTime)
     {
         var totalTime = (float)gameTime.TotalGameTime.TotalSeconds;
@@ -97,9 +74,9 @@ public class BackfaceCullingCube : TGCSample
         var existingRasterizerState = GraphicsDevice.RasterizerState;
         var step = 35f;
         var offset = -step;
-        foreach (var rs in _rasterizerStates)
+        foreach (var cullMode in _cullModes)
         {
-            GraphicsDevice.RasterizerState = rs;
+            GraphicsDevice.RasterizerState = new RasterizerState { CullMode = cullMode, FillMode = _wireframeEnabled ? FillMode.WireFrame : FillMode.Solid };
             var world = Matrix.CreateFromQuaternion(_rotation) * Matrix.CreateTranslation(offset, 0f, 0f);
             _effect.Parameters["World"].SetValue(world);
             _cube.Draw(_effect);
@@ -113,18 +90,25 @@ public class BackfaceCullingCube : TGCSample
         base.Draw(gameTime);
     }
 
-    private void HandleWireframeToggle(bool enabled)
+    /// <inheritdoc />
+    protected override void LoadContent()
     {
-        for (int i = 0; i < _rasterizerStates.Count; i++)
-        {
-            var oldRs = _rasterizerStates[i];
-            var newRs = new RasterizerState
-            {
-                CullMode = oldRs.CullMode,
-                FillMode = enabled ? FillMode.WireFrame : FillMode.Solid,
-            };
-            _rasterizerStates[i] = newRs;
-        }
+        // Load mesh.
+        _cube = new CubePrimitive(GraphicsDevice, 10f, Color.Red, Color.Green, Color.Blue, Color.Yellow, Color.Cyan, Color.Magenta);
+        _effect = Game.Content.Load<Effect>(ContentFolderEffects + "ExplodeColored");
+        _spriteFont = Game.Content.Load<SpriteFont>(ContentFolderSpriteFonts + "CascadiaCode/CascadiaCodePL");
+        ModifierController.AddToggle("Show Wireframe", (enabled) => _wireframeEnabled = enabled, false);
+        base.LoadContent();
+    }
+
+    /// <inheritdoc />
+    protected override void UnloadContent()
+    {
+        _cube.Dispose();
+
+        _effect.Dispose();
+        _spriteFont.Texture.Dispose();
+        base.UnloadContent();
     }
 
     private void DrawLabels()
@@ -139,9 +123,9 @@ public class BackfaceCullingCube : TGCSample
 
         var step = 35f;
         var offset = -step;
-        foreach (var rs in _rasterizerStates)
+        foreach (var cm in _cullModes)
         {
-            string label = rs.CullMode switch
+            string label = cm switch
             {
                 CullMode.CullClockwiseFace => "Cull Clockwise",
                 CullMode.None => "No Culling",


### PR DESCRIPTION
This PR add a sample based on  Threejs's great example to visualize different culling modes.
It shows how to create and set a new `RasterizerState` with different options and provides a great way to visualize the impact of different culling modes.

Inspiration: https://threejs.org/manual/#en/materials

